### PR TITLE
update external trigger

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -23,8 +23,8 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of alpine320 branch. To disable this trigger, add \`python_alpine320\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -s "https://endoflife.date/api/python.json" | jq -r '. | .[0].latest')
-          echo "Type is \`custom_json\`" >> $GITHUB_STEP_SUMMARY
+          EXT_RELEASE=$(curl -u ${{ secrets.CR_USER }}:${{ secrets.CR_PAT }} -sX GET https://api.github.com/repos/python/cpython/tags | jq -r '.[] | select(.name | contains("rc") or contains("a") or contains("b") | not) | .name' | sed 's|^v||g' | sort -rV | head -1)
+          echo "Type is \`custom_version_command\`" >> $GITHUB_STEP_SUMMARY
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
             echo "> Can't retrieve external version, exiting" >> $GITHUB_STEP_SUMMARY

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,8 @@
 
 # jenkins variables
 project_name: docker-python
-external_type: custom_json
+external_type: na
+custom_version_command: "curl -sX GET https://api.github.com/repos/python/cpython/tags | jq -r '.[] | select(.name | contains(\"rc\") or contains(\"a\") or contains(\"b\") | not) | .name' | sed 's|^v||g' | sort -rV | head -1"
 release_type: stable
 release_tag: alpine320
 ls_branch: alpine320
@@ -10,8 +11,6 @@ skip_package_check: true
 unraid_template_sync: false
 unraid_template: false
 repo_vars:
-  - JSON_URL = 'https://endoflife.date/api/python.json'
-  - JSON_PATH = '.[0].latest'
   - BUILD_VERSION_ARG = 'PYTHON_VERSION'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-python'


### PR DESCRIPTION
endoflife.date is not accurate when it comes to new releases: https://github.com/endoflife-date/endoflife.date/pull/5894

This PR will use the cpython repo's tags to sort through and identify the latest stable version